### PR TITLE
Update lambda.tf

### DIFF
--- a/component_infra/lambda.tf
+++ b/component_infra/lambda.tf
@@ -1,7 +1,7 @@
 resource aws_lambda_function lambda_function_bit {
   role             = aws_iam_role.lambda_exec_role.arn
   handler          = "integration.handler"
-  runtime          = "python3.6"
+  runtime          = "python3.9"
   filename         = "integration.zip"
   function_name    = "bitbucket_integrator"
   source_code_hash = filebase64sha256("integration.zip")


### PR DESCRIPTION
creates an error message 
Message_: "The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions."